### PR TITLE
Add data_size to CouchInfo struct

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -12,6 +12,7 @@ type CouchInfo struct {
 	PurgeSeq           int         `json:"purge_seq"`
 	CompactRunning     bool        `json:"compact_running"`
 	DiskSize           int         `json:"disk_size"`
+	DataSize           int         `json:"data_size"`
 	InstanceStartTime  string      `json:"instance_start_time"`
 	DiskFormatVersion  int         `json:"disk_format_version"`
 	CommittedUpdateSeq int         `json:"committed_update_seq"`


### PR DESCRIPTION
couchdb returns an extra element, data_size, in its info response when querying e.g.

http://database.host:5984/dbname/

data_size is different than disk_size, and a large difference between the two can indicate it is time to run compaction.
